### PR TITLE
Introduce as_keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 *.app
 
 build/*
+.cache
+compile_commands.json

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -50,7 +50,7 @@
           [
             <a href="keywords.html">Keywords</a>
           | <a href="settings.html">Settings</a>
-          | <a href="error.html">Error Handling</a>
+          <!-- | <a href="error.html">Error Handling</a> -->
           | <a href="custom.html">Custom Keyword</a>
           | <a href="concepts.html">Concepts</a>
           ]<br/>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -259,11 +259,11 @@ int main()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 'surname' : john (std::__cxx11::basic_string<char>)
 'value' : 3 (float)
-'aligned' : 1 (std::integral_constant<bool, true>)
-'transparent' : 1 (std::integral_constant<bool, true>)
+'aligned' : set
+'transparent' : set
 
 
 'surname' : john (std::__cxx11::basic_string<char>)
 'value' : 3 (float)
-'transparent' : 1 (std::integral_constant<bool, true>)
+'transparent' : set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -9,6 +9,7 @@
 #include <raberu.hpp>
 #include <array>
 #include <string>
+#include <type_traits>
 
 using namespace rbr::literals;
 
@@ -44,13 +45,7 @@ inline constexpr auto factor_ = ::rbr::keyword<small_type>("factor"_id);
 inline constexpr auto is_transparent_ = ::rbr::flag("is_transparent"_id);
 inline constexpr auto is_modal_       = "is_modal"_fl;
 
-struct is_integral_constant
-{
-  template<typename T>      struct apply                               : std::false_type {};
-  template<typename T, T N> struct apply<std::integral_constant<T,N>>  : std::true_type {};
-};
-
-struct unrolling : rbr::checked_keyword<unrolling, is_integral_constant>
+struct unrolling : rbr::as_keyword<unrolling>
 {
   template<int N>
   constexpr auto operator=(std::integral_constant<int,N> const&) const noexcept
@@ -58,7 +53,7 @@ struct unrolling : rbr::checked_keyword<unrolling, is_integral_constant>
     return rbr::option<unrolling,std::integral_constant<int,N>>{};
   }
 
-  std::ostream& name(std::ostream& os) const { return os << "Unroll Factor: "; }
+  std::ostream& display(std::ostream& os, auto v) const { return os << "Unroll Factor: " << v; }
 };
 
 template<int N> inline constexpr auto unroll = (unrolling{} = std::integral_constant<int,N>{});


### PR DESCRIPTION
Simplify definition of keyword inside
raberu and for users by providing a CRTP
base class.