### PR TITLE
Add the nightly matrix run and the README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@
 ##======================================================================================================================
 name: Unit Tests
 on:
+  ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
+  ## the pull requests back. 01:20 UTC, which is 02:20 in Paris in winter, and off the hour that every other
+  ## scheduled workflow on the platform asks for.
+  schedule:
+    - cron: '20 1 * * *'
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 # RABERU - The Fancy Named Parameters Library
 
+[![Release](https://img.shields.io/github/v/release/jfalcou/raberu?style=plastic&label=release)](https://github.com/jfalcou/raberu/releases/latest)
+[![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
+[![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.gg/rfsYYexss)
+[![Integration](https://github.com/jfalcou/raberu/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/raberu/actions/workflows/integration.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/raberu/coverage/badge.json&style=plastic&cacheSeconds=1800)](https://jfalcou.github.io/raberu/coverage/)
+[![CI](https://github.com/jfalcou/raberu/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/jfalcou/raberu/actions/workflows/ci.yml?query=event%3Aschedule)
+
+<br clear="left"/>
+
 **RABERU** provides a way to define and use named parameters, *i.e* a list of values assigned to
 arbitrary keyword-like identifiers, to functions.
 


### PR DESCRIPTION
`ci.yml` also runs on a schedule at 01:20 UTC, twenty minutes off the hour every other scheduled
workflow on the platform asks for. raberu has no `compile-cost.yml`, so no workflow of its own is
triggered by a push any more, and a broken `main` shows up the next morning instead of queueing
behind the pull requests.

The README gains the six badges in the order kumi settled on. The CI one is filtered by
`?event=schedule`, so it reports the night and never a pull request. The Discord link is new: raberu
carried none anywhere.
