### PR TITLE
Add the compile-cost target and its workflow

### DIFF
--- a/.github/workflows/compile-cost.yml
+++ b/.github/workflows/compile-cost.yml
@@ -1,0 +1,28 @@
+##======================================================================================================================
+##  RABERU - Fancy Named Parameter Library
+##  Copyright : RABERU Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## What every test unit costs to compile: a push to main leaves the reference, a pull request reports the delta.
+name: RABERU Compile Cost
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: raberu-compile-cost-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-cost:
+    ## Reading the reference off another run asks more than the contents scope the token defaults to.
+    permissions:
+      actions: read
+      contents: read
+    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    with:
+      project: raberu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ copa_add_option(RABERU_BUILD_TEST "Build tests for Raberu" ON LABEL "Unit tests"
 copa_add_option(RABERU_BUILD_DOCUMENTATION "Build Doxygen for Raberu" OFF LABEL "Doxygen")
 copa_add_option(RABERU_ENABLE_SANITIZERS "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF LABEL "Sanitizers")
 copa_add_option(RABERU_ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF LABEL "Coverage")
+copa_add_option(RABERU_COMPILE_COST "Measure what every test unit costs to compile" OFF)
 
 if(RABERU_BUILD_TEST)
   include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
@@ -87,5 +88,10 @@ if(RABERU_BUILD_TEST)
   # After the test targets exist, so the coverage targets can depend on them
   if(RABERU_ENABLE_COVERAGE)
     copa_setup_coverage(raberu_test)
+  endif()
+
+  # clang only: -fproc-stat-report is its flag. After the test targets, as the measurement rebuilds them.
+  if(RABERU_COMPILE_COST)
+    copa_setup_compile_cost(raberu_test)
   endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -61,6 +61,13 @@
       }
     },
     {
+      "name": "compile-cost",
+      "hidden": true,
+      "cacheVariables": {
+        "RABERU_COMPILE_COST": "ON"
+      }
+    },
+    {
       "name": "clang-libc++",
       "inherits": [
         "libcxx",
@@ -146,6 +153,14 @@
       "name": "clangcl",
       "inherits": "windows-base",
       "toolset": "ClangCL"
+    },
+    {
+      "name": "clang-compile-cost",
+      "inherits": [
+        "clang",
+        "compile-cost"
+      ],
+      "displayName": "Clang, measuring what every unit costs to compile"
     }
   ],
   "buildPresets": [
@@ -215,6 +230,11 @@
       "name": "clangcl",
       "inherits": "base-build",
       "configurePreset": "clangcl"
+    },
+    {
+      "name": "clang-compile-cost",
+      "inherits": "base-build",
+      "configurePreset": "clang-compile-cost"
     }
   ],
   "testPresets": [


### PR DESCRIPTION
The figures only mean something under the preset the CI runs, so `clang-compile-cost` inherits `clang` and turns the option on there and nowhere else.

Nothing on `main` has left a reference artifact yet, so this first run reports absolute figures and says the delta is missing.
